### PR TITLE
Fix typo (`usb` to `-usb`)

### DIFF
--- a/macOS-libvirt-Catalina.xml
+++ b/macOS-libvirt-Catalina.xml
@@ -196,7 +196,7 @@
     <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
-    <qemu:arg value='usb'/>
+    <qemu:arg value='-usb'/>
     <qemu:arg value='-device'/>
     <qemu:arg value='usb-tablet'/>
     <qemu:arg value='-device'/>


### PR DESCRIPTION
This matches the parameters on `OpenCore-Boot.sh` now